### PR TITLE
97-tm.rules

### DIFF
--- a/udev/97-tm.rules
+++ b/udev/97-tm.rules
@@ -1,4 +1,4 @@
-# Thrustmaster TPR Pedal libusb
+# DCS on Linux, Thrustmaster TPR Pedal, libusb, to correct for it not working with hidraw catchall 40-tm.rules
 ACTION=="add", \
   ATTRS{idVendor}=="044f", ATTRS{idProduct}=="b68f", \
   MODE="0664", ENV{ID_INPUT_JOYSTICK}="1", TAG+="uaccess", \

--- a/udev/97-tm.rules
+++ b/udev/97-tm.rules
@@ -1,0 +1,5 @@
+# Thrustmaster TPR Pedal libusb
+ACTION=="add", \
+  ATTRS{idVendor}=="044f", ATTRS{idProduct}=="b68f", \
+  MODE="0664", ENV{ID_INPUT_JOYSTICK}="1", TAG+="uaccess", \
+  RUN+="/usr/bin/evdev-joystick --e %E{DEVNAME} --d 0"


### PR DESCRIPTION
Thustmaster TPR pedals libusb udev rule. The generic Trustmaster udev rule did not detect the pedals.