### PR TITLE
udev: add Total Controls Apache Keyboard Unit rule (04d8:e570)

### DIFF
--- a/udev/40-total-controls.rules
+++ b/udev/40-total-controls.rules
@@ -1,8 +1,4 @@
-# DCS on Linux, Total Controls Apache KU (Microchip vendor 04d8)
-#
-# 04d8 is a generic Microchip ID, so match the exact product. The if03 interface
-# is a clean gamepad HID (usage 0001:0005, 51 buttons on the Button page); with
-# the rw ACL + PROTON_ENABLE_HIDRAW="0x04D8/0xE570" wine exposes all 51 buttons.
+# DCS on Linux Joystick Udev Rules, Total Controls
 
-KERNEL=="hidraw*", ATTRS{idVendor}=="04d8", ATTRS{idProduct}=="e570", MODE="0664", TAG+="uaccess"
-ACTION=="add", ATTRS{idVendor}=="04d8", ATTRS{idProduct}=="e570", MODE="0664", TAG+="uaccess"
+#apache keyboard unit
+KERNEL=="hidraw*", ATTRS{idVendor}=="04d8", ATTRS{idProduct}=="e570", MODE="0664", TAG+="uaccess" 

--- a/udev/40-total-controls.rules
+++ b/udev/40-total-controls.rules
@@ -1,0 +1,8 @@
+# DCS on Linux, Total Controls Apache KU (Microchip vendor 04d8)
+#
+# 04d8 is a generic Microchip ID, so match the exact product. The if03 interface
+# is a clean gamepad HID (usage 0001:0005, 51 buttons on the Button page); with
+# the rw ACL + PROTON_ENABLE_HIDRAW="0x04D8/0xE570" wine exposes all 51 buttons.
+
+KERNEL=="hidraw*", ATTRS{idVendor}=="04d8", ATTRS{idProduct}=="e570", MODE="0664", TAG+="uaccess"
+ACTION=="add", ATTRS{idVendor}=="04d8", ATTRS{idProduct}=="e570", MODE="0664", TAG+="uaccess"


### PR DESCRIPTION
Add a udev rule for the Total Controls Apache KU.

`lsusb`: `ID 04d8:e570 Microchip Technology, Inc. Total Controls Apache KU`

The vendor id 04d8 is a generic Microchip id, so the rule matches the exact
product to avoid grabbing unrelated boards. It grants hidraw uaccess (plus the
usb device node for libusb).
  
Tested on Bazzite: the Apache KU's gamepad interface (51 buttons) is fully
usable in DCS via Proton once the device is forced onto hidraw with PROTON_ENABLE_HIDRAW 